### PR TITLE
HB-4558: Add initial podspec

### DIFF
--- a/ChartboostHeliumAdapterGoogleBidding.podspec
+++ b/ChartboostHeliumAdapterGoogleBidding.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |spec|
+  spec.name        = 'ChartboostHeliumAdapterGoogleBidding'
+  spec.version     = '4.9.1.0.0'
+  spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
+  spec.homepage    = 'https://github.com/ChartBoost/helium-ios-adapter-chartboost'
+  spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
+  spec.summary     = 'Helium iOS SDK Google Bidding adapter.'
+  spec.description = 'Google Bidding Adapters for mediating through Helium. Supported ad formats: Banner, Interstitial, and Rewarded.'
+
+  # Source
+  spec.module_name  = 'HeliumAdapterGoogleBidding'
+  spec.source       = { :git => 'https://github.com/ChartBoost/helium-ios-adapter-google-bidding.git', :tag => '#{spec.version}' }
+  spec.source_files = 'Source/**/*.{swift}'
+
+  # Minimum supported versions
+  spec.swift_version         = '5.0'
+  spec.ios.deployment_target = '10.0'
+
+  # System frameworks used
+  spec.ios.frameworks = ['Foundation', 'UIKit']
+  
+  # This adapter is compatible with all Helium 4.X versions of the SDK.
+  spec.dependency 'ChartboostHelium', '~> 4.0'
+
+  # Partner network SDK and version that this adapter is certified to work with.
+  spec.dependency 'Google-Mobile-Ads-SDK', '9.1.0' 
+end


### PR DESCRIPTION
Add podspec to fulfill Canary app local dependency for development.
Partner SDK version may not be the final one we use when we release, whenever we work on the adapter we should review.
