### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/GoogleBiddingAdapterInterstitialAd.swift
+++ b/Source/GoogleBiddingAdapterInterstitialAd.swift
@@ -79,7 +79,7 @@ extension GoogleBiddingAdapterInterstitialAd: GADFullScreenContentDelegate {
     }
     
     func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
-        log(.showFailed(self.error(.showFailureUnknown, error: error)))
+        log(.showFailed(error))
         showCompletion?(.failure(error)) ?? log(.showResultIgnored)
         showCompletion = nil
     }

--- a/Source/GoogleBiddingAdapterRewardedAd.swift
+++ b/Source/GoogleBiddingAdapterRewardedAd.swift
@@ -83,7 +83,7 @@ extension GoogleBiddingAdapterRewardedAd: GADFullScreenContentDelegate {
     }
     
     func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
-        log(.showFailed(self.error(.showFailureUnknown, error: error)))
+        log(.showFailed(error))
         showCompletion?(.failure(error)) ?? log(.showResultIgnored)
         showCompletion = nil
     }


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
