### PR TITLE
Fix partner SDK version value

### DIFF
--- a/Source/GoogleBiddingAdapter.swift
+++ b/Source/GoogleBiddingAdapter.swift
@@ -21,8 +21,13 @@ enum GoogleStrings {
 final class GoogleBiddingAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
-    lazy var partnerSDKVersion = getGADVersionString()
-
+    var partnerSDKVersion: String {
+        // GADMobileAds SDK version is formatted like "afma-sdk-i-v9.14.0".
+        // We attempt to retrieve only the semantic version by stripping the prefix.
+        GADMobileAds.sharedInstance().sdkVersion
+            .replacingOccurrences(of: "afma-sdk-i-v", with: "")
+    }
+    
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
@@ -249,9 +254,4 @@ final class GoogleBiddingAdapter: PartnerAdapter {
             return GADAdFormat.unknown
         }
     }
-}
-
-func getGADVersionString() -> String {
-    let gadVersion = GADVersionNumber()
-    return "\(gadVersion.majorVersion).\(gadVersion.minorVersion).\(gadVersion.patchVersion)"
 }


### PR DESCRIPTION
It was always 0.0.0.
Note GADVersionNumber is a simple model and it does not represent the GoogleMobileAds SDK version.

I removed the "afma-sdk-i-v" prefix because it's what was done for 3.x, and I didn't want to risk causing trouble with backend at this point.
We can review in the future if passing the original string as is is okay.