### PR TITLE
Make properties constant for safety and compatibility with smoke tests

### DIFF
--- a/Source/GoogleBiddingAdapter.swift
+++ b/Source/GoogleBiddingAdapter.swift
@@ -31,13 +31,13 @@ final class GoogleBiddingAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    var adapterVersion = "4.9.12.0.0"
+    let adapterVersion = "4.9.12.0.0"
     
     /// The partner's unique identifier.
-    var partnerIdentifier = "google_googlebidding"
+    let partnerIdentifier = "google_googlebidding"
     
     /// The human-friendly partner name.
-    var partnerDisplayName = "Google bidding"
+    let partnerDisplayName = "Google bidding"
     
     /// Parameters that should be included in all ad requests
     let sharedExtras = GADExtras()


### PR DESCRIPTION
Fixes [failing smoke test workflow](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-google-bidding/pull/24) which expects a pattern `"let adapterVersion"` to be found in this file.