### PR TITLE
[HB-6729] add privacy manifest

### DIFF
--- a/ChartboostMediationAdapterGoogleBidding.podspec
+++ b/ChartboostMediationAdapterGoogleBidding.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |spec|
   spec.module_name  = 'ChartboostMediationAdapterGoogleBidding'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-google-bidding.git', :tag => spec.version }
   spec.source_files = 'Source/**/*.{swift}'
+  spec.resource_bundles = { 'ChartboostMediationAdapterGoogleBidding' => ['PrivacyInfo.xcprivacy'] }
 
   # Minimum supported versions
   spec.swift_version         = '5.0'

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Source/GoogleBiddingAdapter.swift
+++ b/Source/GoogleBiddingAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterAd.swift
+++ b/Source/GoogleBiddingAdapterAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterBannerAd.swift
+++ b/Source/GoogleBiddingAdapterBannerAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterInterstitialAd.swift
+++ b/Source/GoogleBiddingAdapterInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterRewardedAd.swift
+++ b/Source/GoogleBiddingAdapterRewardedAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterRewardedInterstitialAd.swift
+++ b/Source/GoogleBiddingAdapterRewardedInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Add a privacy manifest to declare `UserDefaults` usage (`NSPrivacyAccessedAPICategoryUserDefaults`).
![image](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-google-bidding/assets/122156786/9f1c9e0b-3bb0-4110-94a6-353d9b5cdac7)

There is no way to test this privacy manifest until it is publicly available, but we have until April 2023 to verify.