### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/Source/GoogleBiddingAdapter.swift
+++ b/Source/GoogleBiddingAdapter.swift
@@ -22,20 +22,25 @@ final class GoogleBiddingAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
     var partnerSDKVersion: String {
-        let versionNumber = GADMobileAds.sharedInstance().versionNumber
-        return "\(versionNumber.majorVersion).\(versionNumber.minorVersion).\(versionNumber.patchVersion)"
+        GoogleBiddingAdapterConfiguration.partnerSDKVersion
     }
-    
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.11.2.0.0"
-    
+    var adapterVersion: String {
+        GoogleBiddingAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "google_googlebidding"
-    
+    var partnerID: String {
+        GoogleBiddingAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Google bidding"
+    var partnerDisplayName: String {
+        GoogleBiddingAdapterConfiguration.partnerDisplayName
+    }
     
     /// Parameters that should be included in all ad requests
     let sharedExtras = GADExtras()

--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -10,6 +10,23 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class GoogleBiddingAdapterConfiguration: NSObject {
 
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        let versionNumber = GADMobileAds.sharedInstance().versionNumber
+        return "\(versionNumber.majorVersion).\(versionNumber.minorVersion).\(versionNumber.patchVersion)"
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.11.2.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "google_googlebidding"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Google bidding"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.google_googlebidding", category: "Configuration")
 
     /// Google's identifier for your test device can be found in the console output from their SDK

--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -30,14 +30,13 @@ import os.log
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.google_googlebidding", category: "Configuration")
 
     /// Google's identifier for your test device can be found in the console output from their SDK
-    class func setTestDeviceId(_ id: String?) {
-        if let id = id {
-            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = [id]
-        } else {
-            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = []
+    @objc public static var testDeviceIdentifiers: [String]? {
+        get {
+            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers
         }
-        if #available(iOS 12.0, *) {
-            os_log(.debug, log: log, "Google Bidding SDK test device ID set to %{public}s", id ?? "nil")
+        set {
+            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = newValue
+            os_log(.debug, log: log, "AdMob SDK test device ID set to %{public}s", newValue ?? "nil")
         }
     }
 }

--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -11,7 +11,7 @@ import os.log
 @objc public class GoogleBiddingAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         let versionNumber = GADMobileAds.sharedInstance().versionNumber
         return "\(versionNumber.majorVersion).\(versionNumber.minorVersion).\(versionNumber.patchVersion)"
     }
@@ -19,13 +19,13 @@ import os.log
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.11.2.0.0"
+    @objc public static let adapterVersion = "4.11.2.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "google_googlebidding"
+    @objc public static let partnerID = "google_googlebidding"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Google bidding"
+    @objc public static let partnerDisplayName = "Google bidding"
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.google_googlebidding", category: "Configuration")
 

--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -36,7 +36,7 @@ import os.log
         }
         set {
             GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = newValue
-            os_log(.debug, log: log, "AdMob SDK test device ID set to %{public}s", newValue ?? "nil")
+            os_log(.debug, log: log, "AdMob SDK test device IDs set to %{public}s", newValue ?? "nil")
         }
     }
 }


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.