### PR TITLE
Fix log

### DIFF
--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -36,7 +36,7 @@ import os.log
         }
         set {
             GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = newValue
-            os_log(.debug, log: log, "AdMob SDK test device IDs set to %{public}s", newValue ?? "nil")
+            os_log(.debug, log: log, "Google Bidding SDK test device IDs set to %{public}s", newValue?.description ?? "nil")
         }
     }
 }


### PR DESCRIPTION
`%{public}s` expects a string but `newValue` is now an array, leading to crashes.