### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,25 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-google-bidding/releases).
+
 ### 5.11.8.0.0
 - This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.8.0.
 
+### 4.11.8.0.0
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.8.0.
+
+### 5.11.7.0.0
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.7.0.
+
+### 4.11.7.0.0
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.7.0.
+
 ### 5.11.6.0.0
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.6.0.
+- Google-Mobile-Ads-SDK 11.6.0 now depends on MarketplaceKit and requires XCode 15.3 or above.
+
+### 4.11.6.0.0
 - This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.6.0.
 - Google-Mobile-Ads-SDK 11.6.0 now depends on MarketplaceKit and requires XCode 15.3 or above.
 


### PR DESCRIPTION
Retroactively update the CHANGELOG to include a link to the official releases page on Github and with Mediation 4 releases (if necessary).