### PR TITLE
Upgrade `4.11.10.0.0` adapter to use v2 of the SCAR API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.11.10.0.1
+- Updated to use v2 of the SCAR API
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.10.0.
+
 ### 4.11.10.0.0
 - This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.10.0.
 

--- a/ChartboostMediationAdapterGoogleBidding.podspec
+++ b/ChartboostMediationAdapterGoogleBidding.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterGoogleBidding'
-  spec.version     = '4.11.10.0.0'
+  spec.version     = '4.11.10.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-google-bidding'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }

--- a/Source/GoogleBiddingAdapter.swift
+++ b/Source/GoogleBiddingAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterAd.swift
+++ b/Source/GoogleBiddingAdapterAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterBannerAd.swift
+++ b/Source/GoogleBiddingAdapterBannerAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterInterstitialAd.swift
+++ b/Source/GoogleBiddingAdapterInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterRewardedAd.swift
+++ b/Source/GoogleBiddingAdapterRewardedAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterRewardedInterstitialAd.swift
+++ b/Source/GoogleBiddingAdapterRewardedInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
This PR updates `4.11.10.0.0` to `4.11.10.0.1`. This is one of many patches for the updating of the Google Bidding adapter to support v2 of the SCAR API.

https://chartboost.atlassian.net/browse/HB-9124

Notes:
- The `GADBannerSignalRequest` object suggests that a size should be provided.  However, I verified that it doesn't seem to be required.  So for now, I've done nothing with the size -- especially since `fetchBidderInformation()` does not provide any information about the desired size.
- DO NOT MERGE since this is a Mediation 4 adapter.