### PR TITLE
Upgrade 4.11.12.0.0 adapter to use v2 of the SCAR API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.11.12.0.1
+- Updated to use v2 of the SCAR API
+- This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.12.0.
+
 ### 4.11.12.0.0
 - This version of the adapter has been certified with Google-Mobile-Ads-SDK 11.12.0.
 

--- a/ChartboostMediationAdapterGoogleBidding.podspec
+++ b/ChartboostMediationAdapterGoogleBidding.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterGoogleBidding'
-  spec.version     = '4.11.12.0.0'
+  spec.version     = '4.11.12.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-google-bidding'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }

--- a/Source/GoogleBiddingAdapter.swift
+++ b/Source/GoogleBiddingAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapter.swift
+++ b/Source/GoogleBiddingAdapter.swift
@@ -29,8 +29,8 @@ final class GoogleBiddingAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.11.12.0.0"
-    
+    let adapterVersion = "4.11.12.0.1"
+
     /// The partner's unique identifier.
     let partnerIdentifier = "google_googlebidding"
     
@@ -90,11 +90,7 @@ final class GoogleBiddingAdapter: PartnerAdapter {
     /// - parameter completion: Closure to be performed with the fetched info.
     func fetchBidderInformation(request: PreBidRequest, completion: @escaping ([String: String]?) -> Void) {
         log(.fetchBidderInfoStarted(request))
-        
-        let gbRequest = GADRequest()
-        gbRequest.requestAgent = "Chartboost"
-        gbRequest.register(sharedExtras)
-        
+
         // Convert from our internal AdFormat type to Google's ad format type
         guard let gbAdFormat = googleAdFormat(from: request.format) else {
             let error = error(.prebidFailureUnknown, description: "Failed to map ad format \(request.format) to GADAdFormat")
@@ -103,8 +99,27 @@ final class GoogleBiddingAdapter: PartnerAdapter {
             return
         }
 
-        GADQueryInfo.createQueryInfo(with: gbRequest, adFormat: gbAdFormat) { queryInfo, error in
-            if let token = queryInfo?.query {
+        let gbRequest: GADSignalRequest
+        switch gbAdFormat {
+        case .banner:
+            gbRequest = GADBannerSignalRequest(signalType: GoogleStrings.queryType)
+        case .interstitial:
+            gbRequest = GADInterstitialSignalRequest(signalType: GoogleStrings.queryType)
+        case .rewarded:
+            gbRequest = GADRewardedSignalRequest(signalType: GoogleStrings.queryType)
+        case .rewardedInterstitial:
+            gbRequest = GADRewardedInterstitialSignalRequest(signalType: GoogleStrings.queryType)
+        default:
+            let error = error(.prebidFailureUnknown, description: "Unsupported google ad format \(gbAdFormat)")
+            log(.fetchBidderInfoFailed(request, error: error))
+            completion(nil)
+            return
+        }
+        gbRequest.requestAgent = "Chartboost"
+        gbRequest.register(sharedExtras)
+
+        GADMobileAds.generateSignal(gbRequest) { signal, error in
+            if let token = signal?.signalString {
                 self.log(.fetchBidderInfoSucceeded(request))
                 completion(["token": token])
             } else {

--- a/Source/GoogleBiddingAdapterAd.swift
+++ b/Source/GoogleBiddingAdapterAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterBannerAd.swift
+++ b/Source/GoogleBiddingAdapterBannerAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterConfiguration.swift
+++ b/Source/GoogleBiddingAdapterConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterInterstitialAd.swift
+++ b/Source/GoogleBiddingAdapterInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterRewardedAd.swift
+++ b/Source/GoogleBiddingAdapterRewardedAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/GoogleBiddingAdapterRewardedInterstitialAd.swift
+++ b/Source/GoogleBiddingAdapterRewardedInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Chartboost, Inc.
+// Copyright 2022-2025 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
This PR updates `4.11.12.0.0` to `4.11.12.0.1`. This is one of many patches for the updating of the Google Bidding adapter to support v2 of the SCAR API.

https://chartboost.atlassian.net/browse/HB-9124

Notes:
- Same changes as performed in https://github.com/ChartBoost/chartboost-mediation-ios-adapter-google-bidding/pull/84
- DO NOT MERGE since this is a Mediation 4 adapter.